### PR TITLE
Change javax.xml.bind to org.apache.commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,9 +103,9 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.0</version>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.12</version>
         </dependency>
 
     </dependencies>

--- a/src/main/java/com/emarsys/escher/Escher.java
+++ b/src/main/java/com/emarsys/escher/Escher.java
@@ -4,7 +4,6 @@ package com.emarsys.escher;
 import com.emarsys.escher.util.DateTime;
 import org.apache.http.client.utils.URIBuilder;
 
-import javax.xml.bind.DatatypeConverter;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -13,6 +12,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
 
 public class Escher {
 
@@ -122,7 +123,7 @@ public class Escher {
 
         Logger.log("Canonicalized request: " + canonicalizedRequest);
         Logger.log("String to sign: " + stringToSign);
-        Logger.log("Signing key: " + DatatypeConverter.printHexBinary(signingKey));
+        Logger.log("Signing key: " + encodeHexString(signingKey, true));
         Logger.log("Signature: " + signature);
 
         return signature;

--- a/src/main/java/com/emarsys/escher/Helper.java
+++ b/src/main/java/com/emarsys/escher/Helper.java
@@ -6,7 +6,6 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URLEncodedUtils;
 
-import javax.xml.bind.DatatypeConverter;
 import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -15,6 +14,8 @@ import java.time.Instant;
 import java.util.*;
 import java.util.function.BinaryOperator;
 import java.util.function.Predicate;
+
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
 
 
 class Helper {
@@ -132,7 +133,7 @@ class Helper {
 
 
     public String calculateSignature(byte[] signingKey, String stringToSign) throws EscherException {
-        return DatatypeConverter.printHexBinary(Hmac.sign(config.getHashAlgo(), signingKey, stringToSign)).toLowerCase();
+        return encodeHexString(Hmac.sign(config.getHashAlgo(), signingKey, stringToSign), true);
     }
 
 

--- a/src/main/java/com/emarsys/escher/util/Hmac.java
+++ b/src/main/java/com/emarsys/escher/util/Hmac.java
@@ -1,29 +1,26 @@
 package com.emarsys.escher.util;
 
 import com.emarsys.escher.EscherException;
+import org.apache.commons.codec.digest.DigestUtils;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
-import javax.xml.bind.DatatypeConverter;
 import java.nio.charset.Charset;
 import java.security.MessageDigest;
 
 public class Hmac {
 
     private static final Charset UTF8 = Charset.forName("UTF-8");
-
+    private static final String HASH_ALGO = "SHA-256";
 
     public static String hash(String text) throws EscherException {
         try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            md.update(text.getBytes(UTF8));
-            byte[] bytes = md.digest();
-            return DatatypeConverter.printHexBinary(bytes).toLowerCase();
+            MessageDigest md = MessageDigest.getInstance(HASH_ALGO);
+            return new DigestUtils(md).digestAsHex(text).toLowerCase();
         } catch (Exception e) {
-            throw new EscherException("Unable to compute hash", e);
+            throw new EscherException("Unable to compute hash: " + e.getMessage(), e);
         }
     }
-
 
     public static byte[] sign(String hashAlgo, String key, String data) throws EscherException {
         return  sign(hashAlgo, key.getBytes(UTF8), data);

--- a/src/test/java/com/emarsys/escher/HelperTest.java
+++ b/src/test/java/com/emarsys/escher/HelperTest.java
@@ -7,13 +7,13 @@ import com.tngtech.java.junit.dataprovider.UseDataProvider;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.xml.bind.DatatypeConverter;
 import java.net.URI;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.codec.binary.Hex.encodeHexString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -35,7 +35,7 @@ public class HelperTest extends TestBase {
         );
 
         assertThat(
-                DatatypeConverter.printHexBinary(signingKey).toLowerCase(),
+                encodeHexString(signingKey, true),
                 is("98f1d889fec4f4421adc522bab0ce1f82e6929c262ed15e5a94c90efd1e3b0e7")
         );
     }

--- a/src/test/java/com/emarsys/escher/util/HmacTest.java
+++ b/src/test/java/com/emarsys/escher/util/HmacTest.java
@@ -1,0 +1,18 @@
+package com.emarsys.escher.util;
+
+import com.emarsys.escher.EscherException;
+import org.junit.Assert;
+import org.junit.Test;
+
+
+public class HmacTest {
+
+    @Test
+    public void testHashGenerationSHA256() throws EscherException {
+        String textToHash = "test text";
+        String expectedHash = "0f46738ebed370c5c52ee0ad96dec8f459fb901c2ca4e285211eddf903bf1598";
+
+        Assert.assertEquals(expectedHash, Hmac.hash(textToHash));
+    }
+
+}


### PR DESCRIPTION
- javax.xml.bind is deprecated: [https://docs.oracle.com/javase/9/docs/api/java.xml.bind-summary.html](url)
- the code also has a slightly better hash generation performance using the commons library