### PR TITLE
Update commons-codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,15 @@
             <version>4.5.13</version>
         </dependency>
 
+        <!-- org.apache.httpcomponents:httpclient@4.5.13 would use 1.11 which has a know vulnerability:
+            https://issues.apache.org/jira/browse/CODEC-134
+            Which is fixed in 1.13. -->
+        <dependency>
+            <groupId>commons-codec</groupId>
+            <artifactId>commons-codec</artifactId>
+            <version>1.15</version>
+        </dependency>
+
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>


### PR DESCRIPTION
org.apache.httpcomponents:httpclient@4.5.13 would use 1.11 which has a know vulnerability:
https://issues.apache.org/jira/browse/CODEC-134
Which is fixed in 1.13.