### PR TITLE
DIME-6543 canonicalize relative URL paths

### DIFF
--- a/src/main/java/com/emarsys/escher/Helper.java
+++ b/src/main/java/com/emarsys/escher/Helper.java
@@ -41,13 +41,9 @@ class Helper {
     }
 
 
-    private String canonicalizePath(EscherRequest request) throws EscherException {
-        try {
-            String path = request.getURI().toURL().getPath();
-            return path.equals("") ? "/" : path;
-        } catch (MalformedURLException e) {
-            throw new EscherException(e);
-        }
+    private String canonicalizePath(EscherRequest request) {
+        String path = request.getURI().getRawPath();
+        return path.isEmpty() ? "/" : path;
     }
 
 
@@ -72,7 +68,7 @@ class Helper {
 
 
     public static String encodeURIComponent(String s) throws UnsupportedEncodingException {
-        // We need this to be uri encoded (' ' => '%20') not x-www-form-urlencoded (' ' => '+') with 
+        // We need this to be uri encoded (' ' => '%20') not x-www-form-urlencoded (' ' => '+') with
         // some of the RFC3986 reserved characters kept as they were (-._~) which is used by URLEncoder.
         // This will result an encoding method similar to other escher libs.
         return URLEncoder.encode(s, "UTF-8")

--- a/src/test/java/com/emarsys/escher/HelperTest.java
+++ b/src/test/java/com/emarsys/escher/HelperTest.java
@@ -140,6 +140,23 @@ public class HelperTest extends TestBase {
         assertThat(canonicalized, containsString("specialchars=-_.~"));
     }
 
+    @Test
+    public void testCanonicalizeWithRelativeUri() throws Exception {
+        TestParam param = parseTestData("get-vanilla");
+        TestParam.Request paramRequest = param.getRequest();
+        paramRequest.setUrl(paramRequest.getUrl() + "?name=John%2BWick");
+
+        URI relativeUri = new URI(paramRequest.getUrl());
+
+        EscherRequestImpl request = new EscherRequestImpl(paramRequest.getMethod(), relativeUri, new ArrayList<>(), paramRequest.getBody());
+
+        Helper helper = new Helper(createConfig(param));
+
+        String canonicalized = helper.canonicalize(request, param.getHeadersToSign());
+
+        assertThat(canonicalized, containsString("name=John%2BWick"));
+    }
+
 
     @Test
     @UseDataProvider("getAddMandatoryHeadersCases")


### PR DESCRIPTION
the built-in java URL only accepts absolute URLs, which prevents us using relative paths. The URI already has this information, so there is no need to convert it to URL, and the escher does not use the host (presented or not), so we can go with relative paths.